### PR TITLE
Parsing env_vars from hash to Array of KeyValuePair objects

### DIFF
--- a/ecs-schedule-runtasks.cfndsl.rb
+++ b/ecs-schedule-runtasks.cfndsl.rb
@@ -1,57 +1,74 @@
 CloudFormation do
 
-    iam_policies = external_parameters.fetch(:scheduler_iam_policies, {})
-    IAM_Role(:EventBridgeInvokeRole) do
-      AssumeRolePolicyDocument ({
-        Statement: [
-          {
-            Effect: 'Allow',
-            Principal: { Service: [ 'events.amazonaws.com' ] },
-            Action: [ 'sts:AssumeRole' ]
-          }
-        ]
-      })
-      Path '/'
-      Policies iam_role_policies(iam_policies)
-    end
-  
-  
-    run_tasks.each do |name, task|
-      schedule = task['schedule']
-      task_name = name.gsub("-","").gsub("_","")
-      container_overrides = {}
-      container_overrides[:name] = task.has_key?('container') ? task['container'] : "#{task['task_definition']}"
-      container_overrides[:command] = task['command'] if task.has_key?('command')
-      container_overrides[:environment] = task['env_vars'] if task.has_key?('env_vars')
-      container_input = {
-        containerOverrides: [container_overrides]
-      }
+  iam_policies = external_parameters.fetch(:scheduler_iam_policies, {})
+  IAM_Role(:EventBridgeInvokeRole) do
+    AssumeRolePolicyDocument ({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: { Service: [ 'events.amazonaws.com' ] },
+          Action: [ 'sts:AssumeRole' ]
+        }
+      ]
+    })
+    Path '/'
+    Policies iam_role_policies(iam_policies)
+  end
 
-      unless schedule.nil?
-        Events_Rule("#{task_name}Schedule") do
-          Name FnSub("${EnvironmentName}-#{name}-schedule")
-          Description FnSub("${EnvironmentName} #{name} schedule")
-          ScheduleExpression schedule
-          State Ref(:State)
-          Targets [{
-            Id: name,
-            Arn: Ref(:EcsClusterArn),
-            RoleArn: FnGetAtt('EventBridgeInvokeRole', 'Arn'),
-            EcsParameters: {
-              TaskDefinitionArn: Ref("#{task['task_definition']}"),
-              TaskCount: 1,
-              LaunchType: 'FARGATE',
-              NetworkConfiguration: {
-                AwsVpcConfiguration: {
-                  Subnets: FnSplit(',', Ref('SubnetIds')),
-                  SecurityGroups: [Ref("#{task['task_definition']}SecurityGroup")],
-                  AssignPublicIp: "DISABLED"
-                }
-              }
-            },
-            Input: FnSub(container_input.to_json())
-          }]
+
+  run_tasks.each do |name, task|
+    schedule = task['schedule']
+    task_name = name.gsub("-","").gsub("_","")
+    container_overrides = {}
+    container_overrides[:name] = task.has_key?('container') ? task['container'] : "#{task['task_definition']}"
+    container_overrides[:command] = task['command'] if task.has_key?('command')
+
+    env_vars = []
+    if !(task['env_vars'].nil?)
+      task['env_vars'].each do |name,value|
+        split_value = value.to_s.split(/\${|}/)
+        if split_value.include? 'environment'
+          fn_join = split_value.map { |x| x == 'environment' ? [ Ref('EnvironmentName'), '.', FnFindInMap('AccountId',Ref('AWS::AccountId'),'DnsDomain') ] : x }
+          env_value = FnJoin('', fn_join.flatten)
+        elsif value == 'cf_version'
+          env_value = cf_version
+        else
+          env_value = value
         end
+        env_vars << { name: name, value: env_value}
+      end
+    end
+    container_overrides.merge!({environment: env_vars }) if env_vars.any?
+
+    container_input = {
+      containerOverrides: [container_overrides]
+    }
+
+    unless schedule.nil?
+      Events_Rule("#{task_name}Schedule") do
+        Name FnSub("${EnvironmentName}-#{name}-schedule")
+        Description FnSub("${EnvironmentName} #{name} schedule")
+        ScheduleExpression schedule
+        State Ref(:State)
+        Targets [{
+          Id: name,
+          Arn: Ref(:EcsClusterArn),
+          RoleArn: FnGetAtt('EventBridgeInvokeRole', 'Arn'),
+          EcsParameters: {
+            TaskDefinitionArn: Ref("#{task['task_definition']}"),
+            TaskCount: 1,
+            LaunchType: 'FARGATE',
+            NetworkConfiguration: {
+              AwsVpcConfiguration: {
+                Subnets: FnSplit(',', Ref('SubnetIds')),
+                SecurityGroups: [Ref("#{task['task_definition']}SecurityGroup")],
+                AssignPublicIp: "DISABLED"
+              }
+            }
+          },
+          Input: FnSub(container_input.to_json())
+        }]
       end
     end
   end
+end

--- a/tests/singletask.test.yaml
+++ b/tests/singletask.test.yaml
@@ -18,6 +18,6 @@ run_tasks:
       - echo
       - hello world
     env_vars:
-      - foo: bar
+      foo: bar
     schedule: rate(1 hour)
     


### PR DESCRIPTION
When setting the environment for the containerOverride, the current pattern described in of the [tests](https://github.com/theonestack/hl-component-ecs-schedule-runtasks/blob/65efaf7c8c3cd4eab3b97b7fc8264f29887b57fb/tests/singletask.test.yaml#L21) is preventing scheduled task from running due to the wrong environment's [format](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html). A work around would be to force the right format in the config:

```
env_vars:
      - name: foo
        value: bar
```

Which ends up being not so intuitive for the user since it differs from pattern for environment variables used in other components. As a solution, I cloned the [function](https://github.com/theonestack/hl-component-ecs-service/blob/d39ec4cd441a4730d6059f0e9e0b748841fbf192/ecs-service.cfndsl.rb#L64-L83) from the ecs-service component for parsing env_vars from hash to Array of KeyValuePair object.